### PR TITLE
fix element selectors for movesElement and activeMove

### DIFF
--- a/app/scripts/Dmitlichess.js
+++ b/app/scripts/Dmitlichess.js
@@ -126,7 +126,8 @@ class Dmitlichess {
 // The move notation should be one of the first element created a lichess page is loaded...
 // @TODO figure a more reliable/efficient way to disable the extension on pages without moves notation
 const observer = new MutationObserver((mutations, observerInstance) => {
-  // Workaround to get $moves-tag in https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scs
+  // Workaround to get $moves-tag set in
+  // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scss#L10
   // The actual element name is changed often.
   const movesElement = document.querySelector('.rcontrols').previousElementSibling;
 

--- a/app/scripts/Dmitlichess.js
+++ b/app/scripts/Dmitlichess.js
@@ -126,7 +126,9 @@ class Dmitlichess {
 // The move notation should be one of the first element created a lichess page is loaded...
 // @TODO figure a more reliable/efficient way to disable the extension on pages without moves notation
 const observer = new MutationObserver((mutations, observerInstance) => {
-  const movesElement = document.querySelector('.rmoves');
+  // Workaround to get $moves-tag in https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scs
+  // The actual element name is changed often.
+  const movesElement = document.querySelector('.rcontrols').previousElementSibling;
 
   if (!movesElement) { return; }
 

--- a/app/scripts/MoveEmitter.js
+++ b/app/scripts/MoveEmitter.js
@@ -24,7 +24,10 @@ class MoveEmitter {
       }
 
       if (!notation) { return; }
-      if (!added.classList.contains('active')) { return; }
+      // If the node is active, it will have $active-class which is renamed often.
+      // As a workaround, just check that it has a class name set.
+      // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scs#L12
+      if (added.classList.length === 0) { return; }
 
       const notationType = isCapture(notation) ? 'capture' : 'move';
       const eventDetail = {

--- a/app/scripts/MoveEmitter.js
+++ b/app/scripts/MoveEmitter.js
@@ -26,7 +26,7 @@ class MoveEmitter {
       if (!notation) { return; }
       // If the node is active, it will have $active-class which is renamed often.
       // As a workaround, just check that it has a class name set.
-      // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scs#L12
+      // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scss#L12
       if (added.classList.length === 0) { return; }
 
       const notationType = isCapture(notation) ? 'capture' : 'move';


### PR DESCRIPTION
Lichess controls class names in this file: https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scss It looks like they often rename the classes (maybe as an anti-cheat?) which caused this extension to break. In this pull request, I made 2 changes:

1. Instead of selecting movesElement directly, I select rControls by name and get the previous sibling element in the DOM. This should work even if they rename rMoves.
2. Lichess annotates the current move with $active-class (which gets renamed often). Instead of checking the exact class name, I changed it to just check that the move has a class name at all. Again, this should work even if they change the active move class name.

I don't know if you have any unit tests, but I cloned the project and loaded the extension into Chrome and the voices worked.