### PR TITLE
Handle cases where movesElement is null

### DIFF
--- a/app/scripts/Dmitlichess.js
+++ b/app/scripts/Dmitlichess.js
@@ -129,7 +129,7 @@ const observer = new MutationObserver((mutations, observerInstance) => {
   // Workaround to get $moves-tag set in
   // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scss#L10
   // The actual element name is changed often.
-  const movesElement = document.querySelector('.rcontrols').previousElementSibling;
+  const movesElement = document.querySelector('.rcontrols')?.previousElementSibling;
 
   if (!movesElement) { return; }
 


### PR DESCRIPTION
This is currently looping an exception on dev tools console, for example, when you're in the main lichess page