### PR TITLE
Fix move list selector for current Lichess (l4x renamed to aPp)

### DIFF
--- a/app/scripts/Dmitlichess.js
+++ b/app/scripts/Dmitlichess.js
@@ -133,7 +133,7 @@ const observer = new MutationObserver((mutations, observerInstance) => {
   // Workaround to get $moves-tag set in
   // https://github.com/ornicar/lila/blob/master/ui/round/css/_constants.scss#L10
   // The actual element name is changed often.
-  const movesElement = document.querySelector('l4x');
+  const movesElement = document.querySelector('aPp, l4x');
 
   if (!movesElement) { return; }
 


### PR DESCRIPTION
Lichess renamed its obfuscated move-list tag from `l4x` to `aPp` (see ui/round/css/_constants.scss in lichess-org/lila), so the bootstrap observer never found the move list and the extension never initialized. This queries both the new and old tag, so the extension works on current and older Lichess markup.

   Tested by loading the patched extension unpacked in Chrome on lichess.org/tv — commentary plays.

   Fixes #45
   
   Note: #44 also addresses the l4x rename. This PR is a minimal alternative: it keeps `l4x` as a fallback selector and leaves MoveEmitter untouched (its class-based check already survives the active-class rename).